### PR TITLE
fix: set defaulted attributes as optional

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -14,7 +14,7 @@ variable "subscribers" {
     raw_message_delivery = optional(bool)
     # Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false)
   }))
-  description = "Required configuration for subscibres to SNS topic."
+  description = "Required configuration for subscribes to SNS topic."
   default     = {}
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -9,9 +9,9 @@ variable "subscribers" {
     # The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially supported, see below) (email is an option but is unsupported, see below).
     endpoint = string
     # The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
-    endpoint_auto_confirms = bool
+    endpoint_auto_confirms = optional(bool)
     # Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty (default is false)
-    raw_message_delivery = bool
+    raw_message_delivery = optional(bool)
     # Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false)
   }))
   description = "Required configuration for subscibres to SNS topic."


### PR DESCRIPTION
As seen in the comment that was already there, `endpoint_auto_confirms` and `raw_message_delivery` has a default of false. It is default `false` in the upstream CloudPosse module, AND in the Terraform AWS provider.

Hence, this should be set as optional variable. If it's already default as false, it's pretty [WET](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself#WET) to have to explicitly write "false" when it's already defaulted false. 

Tremendously minor nit!

Also fixes a typo. Minor minor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the `endpoint_auto_confirms` and `raw_message_delivery` fields optional when configuring subscribers. These fields can now be omitted if not needed.
* **Bug Fixes**
  * Corrected a typo in the subscriber configuration description for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->